### PR TITLE
Add Vagrant config.

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+Vagrantfile.local

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,80 @@
+########################################
+# Load in local settings from Vagrantfile.local this should be a yaml
+# file which look similar to:
+#
+#---
+#ansible_groups:
+#  devtest:
+#    - test1
+#    - test2
+#
+#dev_nodes:
+#  - hostname: test1
+#    ip: 172.16.36.10
+#  - hostname: test2
+#    ip: 172.16.36.20
+#
+#
+# This would allow for 2 test nodes, and place them both in the "devtest"
+# group. If you are happy with the default nodes and groups you can leave
+# this blank.
+####################
+require 'yaml'
+settings = {}
+settings = YAML.load_file 'Vagrantfile.local' if File.exist?('Vagrantfile.local')
+########################################
+
+########################################
+# Set some defaults incase there is no Vagrantfile.local or it doesn't
+# contain everything.
+####################
+settings['dev_nodes'] = [
+	{'hostname' => 'infra1', 'ip' => '172.16.36.10'},
+	{'hostname' => 'infra2', 'ip' => '172.16.36.20'},
+	{'hostname' => 'infra3', 'ip' => '172.16.36.30'},
+] if not settings.has_key?('dev_nodes')
+
+settings['ansible_groups'] = {
+	'test' => ["infra1", "infra2", "infra3"],
+} if not settings.has_key?('ansible_groups')
+########################################
+
+########################################
+# Set the Ansible configuration path, this is separate from the provisioner
+# at this time
+####################
+ENV['ANSIBLE_CONFIG'] = "ansible.cfg"
+########################################
+
+########################################
+# Actually set up vagrant!
+####################
+Vagrant.configure("2") do |config|
+	# Define a vagrant client for each node in the array
+	settings['dev_nodes'].each do |node|
+		config.vm.define node['hostname'] do |node_config|
+			# Base box configuration
+			node_config.vm.box = 'ubuntu/trusty64'
+
+			# Hostname and network configuration
+			node_config.vm.hostname = node['hostname'] + '.' + ".test.dmdirc.com"
+			node_config.vm.network :private_network, ip: node['ip']
+
+			# Increase the RAM
+			config.vm.provider :virtualbox do |vb|
+				vb.customize ["modifyvm", :id, "--memory", 512]
+			end
+
+			# Provision with ansible.
+			config.vm.provision "ansible" do |ansible|
+				# We login as "vagrant" not root, so we need to use sudo even
+				# though our playbook doesn't usually.
+				ansible.sudo = true
+				ansible.playbook = "all.yml"
+				ansible.host_key_checking = false
+				ansible.groups = settings['ansible_groups']
+			end
+		end
+	end
+end
+########################################


### PR DESCRIPTION
At the moment this uses VirtualBox, I'll look at changing it to
another time.

Vagrant crash course:

`vagrant up infra1` - Create/Start the "infra1" vm and try to provision it
`vagrant provision infra1` - After making changes, try to re-apply them to "infra1"
`vagrant ssh infra1` - SSH into "infra1" as the vagrant user
`vagrant ssh-config infra1` - Show ssh settings for "infra1"
`vagrant halt infra1` - Shut down "infra1"
`vagrant destroy infra1` - Destroy "infra1" as we no longer need it

I've setup the Vagrantfile to look for a Vagrantfile.local yaml file
to allow changing some settings (such as which groups the nodes are
assigned to, or the actual nodes themselves).

At the moment the nodes come up with an natted internet-breakout network
(eth0) and a private internal network (eth1). The latter is probably
un-needed for us, if so I'll remove it.

Probably also want to make the memory-per-vm configurable at some point
as well.
